### PR TITLE
Add Nowhere UDP-over-TCP client support

### DIFF
--- a/Anywhere TV/TVProxyEditorViewController.swift
+++ b/Anywhere TV/TVProxyEditorViewController.swift
@@ -80,7 +80,7 @@ class TVProxyEditorViewController: UITableViewController {
     private var nowhereKey = ""
     private var nowhereSpec = ""
     private var nowhereNetwork: NowhereNetwork = .udp
-    private var nowherePoolEnabled = false
+    private var nowherePoolEnabled = true
     private var nowherePoolValue = NowherePool.enabledDefault
     private var nowhereSNI = ""
     private var nowhereALPN = ""
@@ -309,10 +309,10 @@ class TVProxyEditorViewController: UITableViewController {
                 ),
             ]
             if nowhereNetwork == .tcp {
-                transportRows.append(.toggle(label: String(localized: "Boost"), isOn: nowherePoolEnabled, key: .nowherePoolEnabled, systemImage: "speedometer"))
+                transportRows.append(.toggle(label: String(localized: "Preconnect"), isOn: nowherePoolEnabled, key: .nowherePoolEnabled, systemImage: "link.badge.plus"))
                 if nowherePoolEnabled {
                     transportRows.append(.selection(
-                        label: String(localized: "Boost"),
+                        label: String(localized: "Connections"),
                         value: String(nowherePoolValue),
                         options: NowherePool.sliderRange.map { (String($0), String($0)) },
                         key: .nowherePool
@@ -924,7 +924,7 @@ class TVProxyEditorViewController: UITableViewController {
             nowhereKey = key
             nowhereSpec = spec ?? ""
             nowhereNetwork = net
-            nowherePoolEnabled = pool > 0
+            nowherePoolEnabled = net == .tcp ? pool > 0 : true
             nowherePoolValue = pool > 0 ? pool : NowherePool.enabledDefault
             nowhereSNI = tls.serverName
             nowhereALPN = tls.alpn?.first ?? ""
@@ -1132,7 +1132,7 @@ class TVProxyEditorViewController: UITableViewController {
             )
         case .nowhere:
             let spec = nowhereSpec.isEmpty ? nil : nowhereSpec
-            let pool = nowherePoolEnabled
+            let pool = nowhereNetwork == .tcp && nowherePoolEnabled
                 ? min(
                     NowherePool.sliderRange.upperBound,
                     max(NowherePool.sliderRange.lowerBound, nowherePoolValue)

--- a/Anywhere/Views/Proxies/ProxyEditorView.swift
+++ b/Anywhere/Views/Proxies/ProxyEditorView.swift
@@ -78,7 +78,7 @@ struct ProxyEditorView: View {
     @State private var nowhereKey = ""
     @State private var nowhereSpec = ""
     @State private var nowhereNetwork: NowhereNetwork = .udp
-    @State private var nowherePoolEnabled = false
+    @State private var nowherePoolEnabled = true
     @State private var nowherePoolSliderValue = Double(NowherePool.enabledDefault)
     @State private var nowhereSNI = ""
     @State private var nowhereALPN = ""
@@ -642,23 +642,23 @@ struct ProxyEditorView: View {
                     Text(verbatim: "TCP").tag(NowhereNetwork.tcp)
                     Text(verbatim: "UDP").tag(NowhereNetwork.udp)
                 } label: {
-                    TextWithColorfulIcon(title: "Network", comment: nil, systemName: "globe", foregroundColor: .white, backgroundColor: .indigo)
+                    TextWithColorfulIcon(title: "Network", comment: nil, systemName: "globe", foregroundColor: .white, backgroundColor: .blue)
                 }
                 if nowhereNetwork == .tcp {
                     Toggle(isOn: $nowherePoolEnabled) {
-                        TextWithColorfulIcon(title: "Boost", comment: nil, systemName: "speedometer", foregroundColor: .white, backgroundColor: .orange)
+                        TextWithColorfulIcon(title: "Preconnect", comment: nil, systemName: "link.badge.plus", foregroundColor: .white, backgroundColor: .orange)
                     }
                     if nowherePoolEnabled {
                         Slider(
                             value: $nowherePoolSliderValue,
                             in: Double(NowherePool.sliderRange.lowerBound)...Double(NowherePool.sliderRange.upperBound)
                         ) {
-                            EmptyView()
+                            Text("Connections")
                         } minimumValueLabel: {
-                            Image(systemName: "gauge.with.dots.needle.0percent")
+                            Image(systemName: "dial.low")
                                 .foregroundStyle(.secondary)
                         } maximumValueLabel: {
-                            Image(systemName: "gauge.with.dots.needle.100percent")
+                            Image(systemName: "dial.high")
                                 .foregroundStyle(.secondary)
                         }
                     }
@@ -1133,7 +1133,7 @@ struct ProxyEditorView: View {
             nowhereKey = key
             nowhereSpec = spec ?? ""
             nowhereNetwork = net
-            nowherePoolEnabled = pool > 0
+            nowherePoolEnabled = net == .tcp ? pool > 0 : true
             nowherePoolSliderValue = Double(pool > 0 ? pool : NowherePool.enabledDefault)
             nowhereSNI = tls.serverName
             nowhereALPN = tls.alpn?.first ?? ""
@@ -1357,7 +1357,7 @@ struct ProxyEditorView: View {
             )
         case .nowhere:
             let spec = nowhereSpec.isEmpty ? nil : nowhereSpec
-            let pool = nowherePoolEnabled
+            let pool = nowhereNetwork == .tcp && nowherePoolEnabled
                 ? min(
                     NowherePool.sliderRange.upperBound,
                     max(NowherePool.sliderRange.lowerBound, Int(nowherePoolSliderValue.rounded()))

--- a/Shared/Localizable.xcstrings
+++ b/Shared/Localizable.xcstrings
@@ -3368,54 +3368,106 @@
         }
       }
     },
-    "Boost" : {
+    "Preconnect" : {
       "localizations" : {
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "تسريع"
+            "value" : "اتصال مسبق"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Boost"
+            "value" : "Preconnect"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Acelerar"
+            "value" : "Preconectar"
           }
         },
         "fa" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "شتاب"
+            "value" : "پیش‌اتصال"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ускорение"
+            "value" : "Предподключение"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hızlandırma"
+            "value" : "Ön bağlantı"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tăng tốc"
+            "value" : "Kết nối trước"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "加速"
+            "value" : "预连接"
+          }
+        }
+      }
+    },
+    "Connections" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اتصالات"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connections"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conexiones"
+          }
+        },
+        "fa" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اتصال‌ها"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подключения"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bağlantılar"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kết nối"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "连接数"
           }
         }
       }
@@ -11634,58 +11686,6 @@
         }
       }
     },
-    "Proxy Mode" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "وضع البروكسي"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proxy Mode"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modo proxy"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "حالت پروکسی"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Режим прокси"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proxy Modu"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chế độ proxy"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "代理模式"
-          }
-        }
-      }
-    },
     "Proxy Type" : {
       "localizations" : {
         "ar" : {
@@ -15315,110 +15315,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "支持代理、订阅和 Clash 链接"
-          }
-        }
-      }
-    },
-    "Switch between Proxy Mode and Global Mode." : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "التبديل بين وضع البروكسي والوضع العام."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Switch between Proxy Mode and Global Mode."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambia entre el Modo proxy y el Modo global."
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "جابجایی بین حالت پروکسی و حالت سراسری."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Переключение между Режимом прокси и Глобальным режимом."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proxy Modu ile Küresel Mod arasında geçiş yapar."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chuyển đổi giữa Chế độ proxy và Chế độ toàn cục."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在代理模式与全局模式之间切换。"
-          }
-        }
-      }
-    },
-    "Switch Mode" : {
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تبديل الوضع"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Switch Mode"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambiar modo"
-          }
-        },
-        "fa" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تغییر حالت"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Переключить режим"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mod Değiştir"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chuyển chế độ"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "切换模式"
           }
         }
       }

--- a/Shared/Networking/Protocols/Core/ProxyClient.swift
+++ b/Shared/Networking/Protocols/Core/ProxyClient.swift
@@ -149,13 +149,6 @@ nonisolated class ProxyClient {
         initialData: Data?,
         completion: @escaping (Result<ProxyConnection, Error>) -> Void
     ) {
-        if configuration.outboundProtocol == .nowhere,
-           configuration.nowhereNetwork == .tcp,
-           command == .udp {
-            completion(.failure(ProxyError.dropped))
-            return
-        }
-
         guard let chain = configuration.chain, !chain.isEmpty, tunnel == nil else {
             connectWithCommand(
                 command: command,

--- a/Shared/Networking/Protocols/Core/ProxyConfiguration+URLExport.swift
+++ b/Shared/Networking/Protocols/Core/ProxyConfiguration+URLExport.swift
@@ -134,7 +134,10 @@ extension ProxyConfiguration {
         }
         let encodedKey = key.addingPercentEncoding(withAllowedCharacters: .urlPasswordAllowed) ?? ""
         let fragment = name.addingPercentEncoding(withAllowedCharacters: .urlFragmentAllowed) ?? name
-        var parameters: [String] = ["net=\(net.rawValue)", "pool=\(pool)"]
+        var parameters: [String] = ["net=\(net.rawValue)"]
+        if net == .tcp {
+            parameters.append("pool=\(pool)")
+        }
         if let spec, !spec.isEmpty {
             parameters.append("spec=\(encodedQueryValue(spec))")
         }
@@ -143,9 +146,6 @@ extension ProxyConfiguration {
         }
         if let alpn = tls.alpn?.first, !alpn.isEmpty {
             parameters.append("alpn=\(encodedQueryValue(alpn))")
-        }
-        if let ech = tls.echQueryValue {
-            parameters.append("ech=\(ech)")
         }
         let query = parameters.isEmpty ? "" : "?\(parameters.joined(separator: "&"))"
         return "nowhere://\(encodedKey)@\(bracketedServerAddress):\(serverPort)\(query)#\(fragment)"

--- a/Shared/Networking/Protocols/Core/ProxyConfiguration+URLParsing.swift
+++ b/Shared/Networking/Protocols/Core/ProxyConfiguration+URLParsing.swift
@@ -154,7 +154,7 @@ extension ProxyConfiguration {
         )
     }
 
-    /// Parses `nowhere://<key>@host:port?net=udp|tcp&spec=...&sni=...&alpn=...#name`.
+    /// Parses `nowhere://<key>@host:port?net=udp|tcp&spec=...&sni=...&alpn=...&pool=0..9#name`.
     private static func parseNowhere(url: String) throws -> ProxyConfiguration {
         let body = try splitLinkBody(url, scheme: "nowhere://", label: "Nowhere")
         let parameters = body.parameters
@@ -174,10 +174,13 @@ extension ProxyConfiguration {
         } else {
             throw ProxyError.invalidURL("Invalid Nowhere net value")
         }
+        if network == .udp, parameters["pool"] != nil {
+            throw ProxyError.invalidURL("Nowhere pool is only valid with net=tcp")
+        }
         let rawPool = parameters["pool"] ?? ""
         let pool: Int
         if rawPool.isEmpty {
-            pool = 0
+            pool = network == .tcp ? NowherePool.enabledDefault : 0
         } else if let parsed = Int(rawPool), NowherePool.validRange.contains(parsed) {
             pool = parsed
         } else {

--- a/Shared/Networking/Protocols/Core/ProxyConfiguration.swift
+++ b/Shared/Networking/Protocols/Core/ProxyConfiguration.swift
@@ -110,7 +110,13 @@ enum Outbound: Hashable {
         sni: String
     )
     /// Nowhere runs over QUIC/UDP or TLS/TCP with a shared-key auth frame.
-    case nowhere(key: String, spec: String?, net: NowhereNetwork, pool: Int, securityLayer: GenericSecurityLayer)
+    case nowhere(
+        key: String,
+        spec: String?,
+        net: NowhereNetwork,
+        pool: Int,
+        securityLayer: GenericSecurityLayer
+    )
     /// Trojan: SHA224(password)+CRLF+request over mandatory TLS. No plaintext variant.
     case trojan(password: String, securityLayer: GenericSecurityLayer)
     /// AnyTLS: stream multiplexer over pooled TLS sessions, authenticated with SHA256(password);
@@ -302,7 +308,9 @@ struct ProxyConfiguration: Identifiable, Hashable, Codable {
             case .udp:
                 return .udp
             case .tcp:
-                return downstreamCommand == .tcp ? .tcp : nil
+                if downstreamCommand == .tcp { return .tcp }
+                if downstreamCommand == .udp { return .tcp }
+                return nil
             }
         }
         return outboundProtocol.upstreamCommand(for: downstreamCommand)
@@ -475,13 +483,13 @@ struct ProxyConfiguration: Identifiable, Hashable, Codable {
             }
             let pool: Int
             if !container.contains(.pool) {
-                pool = 0
+                pool = network == .tcp ? NowherePool.enabledDefault : 0
             } else if try container.decodeNil(forKey: .pool) {
-                pool = 0
+                pool = network == .tcp ? NowherePool.enabledDefault : 0
             } else if let value = try? container.decode(Int.self, forKey: .pool) {
                 pool = value
             } else if let raw = try? container.decode(String.self, forKey: .pool), raw.isEmpty {
-                pool = 0
+                pool = network == .tcp ? NowherePool.enabledDefault : 0
             } else {
                 throw DecodingError.dataCorruptedError(
                     forKey: .pool,
@@ -626,7 +634,9 @@ struct ProxyConfiguration: Identifiable, Hashable, Codable {
             try container.encode(key, forKey: .nowhereKey)
             try container.encodeIfPresent(spec, forKey: .nowhereSpec)
             try container.encode(net.rawValue, forKey: .net)
-            try container.encode(pool, forKey: .pool)
+            if net == .tcp {
+                try container.encode(pool, forKey: .pool)
+            }
             try container.encode(tls.serverName, forKey: .nowhereSNI)
             if let alpn = tls.alpn?.first, !alpn.isEmpty {
                 try container.encode(alpn, forKey: .nowhereALPN)

--- a/Shared/Networking/Protocols/Nowhere/NowhereConnection.swift
+++ b/Shared/Networking/Protocols/Nowhere/NowhereConnection.swift
@@ -7,6 +7,11 @@
 
 import Foundation
 
+enum NowhereTCPRelayMode {
+    case tcp
+    case udp
+}
+
 nonisolated final class NowhereConnection: ProxyConnection {
 
     enum State { case idle, openingStream, handshaking, ready, closed }
@@ -242,6 +247,88 @@ nonisolated final class NowhereConnection: ProxyConnection {
     }
 }
 
+nonisolated final class NowhereTCPUDPConnection: ProxyConnection, UDPFramingCapable {
+
+    private let inner: NowhereTCPConnection
+
+    var udpBuffer = Data()
+    var udpBufferOffset = 0
+    let udpLock = UnfairLock()
+
+    init(inner: NowhereTCPConnection) {
+        self.inner = inner
+        super.init()
+    }
+
+    override var isConnected: Bool { inner.isConnected }
+    override var outerTLSVersion: TLSVersion? { inner.outerTLSVersion }
+    override var deliversDatagrams: Bool { true }
+
+    override func send(data: Data, completion: @escaping (Error?) -> Void) {
+        super.send(data: frameUDPPacket(data), completion: completion)
+    }
+
+    override func send(data: Data) {
+        super.send(data: frameUDPPacket(data))
+    }
+
+    override func sendRaw(data: Data, completion: @escaping (Error?) -> Void) {
+        inner.sendRaw(data: data, completion: completion)
+    }
+
+    override func sendRaw(data: Data) {
+        inner.sendRaw(data: data)
+    }
+
+    override func receive(completion: @escaping (Data?, Error?) -> Void) {
+        udpLock.lock()
+        if let packet = extractUDPPacket() {
+            udpLock.unlock()
+            completion(packet, nil)
+            return
+        }
+        udpLock.unlock()
+        receiveMore(completion: completion)
+    }
+
+    override func receiveRaw(completion: @escaping (Data?, Error?) -> Void) {
+        inner.receiveRaw(completion: completion)
+    }
+
+    private func receiveMore(completion: @escaping (Data?, Error?) -> Void) {
+        inner.receive { [weak self] data, error in
+            guard let self else {
+                completion(nil, ProxyError.connectionFailed("Connection deallocated"))
+                return
+            }
+            if let error {
+                completion(nil, error)
+                return
+            }
+            guard let data else {
+                completion(nil, nil)
+                return
+            }
+            self.udpLock.lock()
+            self.udpBuffer.append(data)
+            if let packet = self.extractUDPPacket() {
+                self.udpLock.unlock()
+                completion(packet, nil)
+            } else {
+                self.udpLock.unlock()
+                self.receiveMore(completion: completion)
+            }
+        }
+    }
+
+    override func cancel() {
+        udpLock.lock()
+        clearUDPBuffer()
+        udpLock.unlock()
+        inner.cancel()
+    }
+}
+
 nonisolated final class NowhereTCPConnection: ProxyConnection {
 
     private enum State { case idle, connecting, authenticating, prepared, requesting, ready, closed }
@@ -302,16 +389,17 @@ nonisolated final class NowhereTCPConnection: ProxyConnection {
         connectAndSend(payload: auth, successState: .prepared, completion: completion)
     }
 
-    func openFresh(destination: String, completion: @escaping (Error?) -> Void) {
+    func openFresh(
+        destination: String,
+        mode: NowhereTCPRelayMode = .tcp,
+        completion: @escaping (Error?) -> Void
+    ) {
         let bootstrap: Data
         do {
             bootstrap = try NowhereProtocol.makeAuthFrame(
                 key: configuration.key,
                 protocolSpec: configuration.protocolSpec
-            ) + NowhereProtocol.encodeTCPRequest(
-                address: destination,
-                protocolSpec: configuration.protocolSpec
-            )
+            ) + requestPayload(destination: destination, mode: mode)
         } catch {
             completion(error)
             return
@@ -320,13 +408,14 @@ nonisolated final class NowhereTCPConnection: ProxyConnection {
         connectAndSend(payload: bootstrap, successState: .ready, completion: completion)
     }
 
-    func activate(destination: String, completion: @escaping (Error?) -> Void) {
+    func activate(
+        destination: String,
+        mode: NowhereTCPRelayMode = .tcp,
+        completion: @escaping (Error?) -> Void
+    ) {
         let request: Data
         do {
-            request = try NowhereProtocol.encodeTCPRequest(
-                address: destination,
-                protocolSpec: configuration.protocolSpec
-            )
+            request = try requestPayload(destination: destination, mode: mode)
         } catch {
             completion(error)
             return
@@ -359,6 +448,23 @@ nonisolated final class NowhereTCPConnection: ProxyConnection {
             }
             callback?(nil)
             self.deliverPendingReceive()
+        }
+    }
+
+    private func requestPayload(destination: String, mode: NowhereTCPRelayMode) throws -> Data {
+        switch mode {
+        case .tcp:
+            return try NowhereProtocol.encodeTCPRequest(
+                address: destination,
+                protocolSpec: configuration.protocolSpec
+            )
+        case .udp:
+            var payload = try NowhereProtocol.encodeTCPRequest(
+                address: NowhereProtocol.uotMagicTarget,
+                protocolSpec: configuration.protocolSpec
+            )
+            payload.append(try NowhereProtocol.encodeUOTSetupTarget(destination))
+            return payload
         }
     }
 

--- a/Shared/Networking/Protocols/Nowhere/NowhereProtocol.swift
+++ b/Shared/Networking/Protocols/Nowhere/NowhereProtocol.swift
@@ -14,6 +14,7 @@ enum NowhereProtocol {
     
     static let closeErrCodeOK: UInt64 = 0x100
     static let defaultSpec = "auto"
+    static let uotMagicTarget = "uot.nowhere.invalid:0"
 
     private static let proxyFrameVersion: UInt8 = 1
     private static let defaultALPN = "now/1"
@@ -317,6 +318,10 @@ enum NowhereProtocol {
         out.append(header)
         out.append(payload)
         return out
+    }
+
+    static func encodeUOTSetupTarget(_ target: String) throws -> Data {
+        try encodeTarget(target)
     }
 
     private static func encodeUDPHeader(type: UDPType, flowID: UInt64, target: String, protocolSpec: EffectiveSpec) throws -> Data {

--- a/Shared/Networking/Protocols/Nowhere/NowhereTCPConnectionPool.swift
+++ b/Shared/Networking/Protocols/Nowhere/NowhereTCPConnectionPool.swift
@@ -42,6 +42,7 @@ nonisolated final class NowhereTCPConnectionPoolRegistry {
         configuration: NowhereConfiguration,
         connectHost: String,
         destination: String,
+        mode: NowhereTCPRelayMode = .tcp,
         completion: @escaping (Result<ProxyConnection, Error>) -> Void
     ) {
         let key = Key(
@@ -76,7 +77,7 @@ nonisolated final class NowhereTCPConnectionPoolRegistry {
             return pool
         }
         replaced?.closeAll()
-        pool.acquire(destination: destination, completion: completion)
+        pool.acquire(destination: destination, mode: mode, completion: completion)
     }
 
     func closeAll() {
@@ -140,6 +141,7 @@ nonisolated private final class NowhereTCPConnectionPool {
 
     func acquire(
         destination: String,
+        mode: NowhereTCPRelayMode,
         completion: @escaping (Result<ProxyConnection, Error>) -> Void
     ) {
         var selected: NowhereTCPConnection?
@@ -189,20 +191,20 @@ nonisolated private final class NowhereTCPConnectionPool {
 
         if let selected {
             selected.setPreparedCloseHandler(nil)
-            selected.activate(destination: destination) { [weak self] error in
+            selected.activate(destination: destination, mode: mode) { [weak self] error in
                 if error != nil {
                     selected.cancel()
                     guard let self else {
                         completion(.failure(ProxyError.connectionFailed("Nowhere TCP pool closed during acquire")))
                         return
                     }
-                    self.openFresh(destination: destination, completion: completion)
+                    self.openFresh(destination: destination, mode: mode, completion: completion)
                 } else {
-                    completion(.success(selected))
+                    completion(.success(Self.proxyConnection(selected, mode: mode)))
                 }
             }
         } else {
-            openFresh(destination: destination, completion: completion)
+            openFresh(destination: destination, mode: mode, completion: completion)
         }
     }
 
@@ -226,6 +228,7 @@ nonisolated private final class NowhereTCPConnectionPool {
 
     private func openFresh(
         destination: String,
+        mode: NowhereTCPRelayMode,
         completion: @escaping (Result<ProxyConnection, Error>) -> Void
     ) {
         let connection = NowhereTCPConnection(
@@ -233,13 +236,25 @@ nonisolated private final class NowhereTCPConnectionPool {
             connectHost: connectHost,
             tunnel: nil
         )
-        connection.openFresh(destination: destination) { error in
+        connection.openFresh(destination: destination, mode: mode) { error in
             if let error {
                 connection.cancel()
                 completion(.failure(error))
             } else {
-                completion(.success(connection))
+                completion(.success(Self.proxyConnection(connection, mode: mode)))
             }
+        }
+    }
+
+    private static func proxyConnection(
+        _ connection: NowhereTCPConnection,
+        mode: NowhereTCPRelayMode
+    ) -> ProxyConnection {
+        switch mode {
+        case .tcp:
+            return connection
+        case .udp:
+            return NowhereTCPUDPConnection(inner: connection)
         }
     }
 

--- a/Shared/Networking/Protocols/Nowhere/ProxyClient+Nowhere.swift
+++ b/Shared/Networking/Protocols/Nowhere/ProxyClient+Nowhere.swift
@@ -47,7 +47,13 @@ extension ProxyClient {
         }
 
         if net == .tcp {
-            guard command == .tcp else {
+            let mode: NowhereTCPRelayMode
+            switch command {
+            case .tcp:
+                mode = .tcp
+            case .udp:
+                mode = .udp
+            default:
                 completion(.failure(ProxyError.dropped))
                 return
             }
@@ -57,6 +63,7 @@ extension ProxyClient {
                     configuration: nwConfig,
                     connectHost: directDialHost,
                     destination: destination,
+                    mode: mode,
                     completion: completion
                 )
                 return
@@ -68,12 +75,17 @@ extension ProxyClient {
                 tunnel: tunnel
             )
             tunnel = nil
-            connection.openFresh(destination: destination) { error in
+            connection.openFresh(destination: destination, mode: mode) { error in
                 if let error {
                     connection.cancel()
                     completion(.failure(error))
                 } else {
-                    completion(.success(connection))
+                    switch mode {
+                    case .tcp:
+                        completion(.success(connection))
+                    case .udp:
+                        completion(.success(NowhereTCPUDPConnection(inner: connection)))
+                    }
                 }
             }
             return


### PR DESCRIPTION
- route Nowhere `net=tcp` UDP flows through UDP-over-TCP instead of dropping them
- add TCP relay modes for ordinary TCP and UDP-over-TCP activation, including warm pool reuse
- wrap TCP UoT connections with UDP packet framing for datagram send/receive
- default Nowhere TCP preconnect to `pool=5`, while preserving explicit `pool=0` as disabled
- update Nowhere editor UI to show `Preconnect` / `Connections` with localized strings on iOS and tvOS
- export `pool` only for `net=tcp`; keep `net=udp` exports free of pool settings